### PR TITLE
Send multiple initialisation messages to code editor until loaded

### DIFF
--- a/src/app/components/content/IsaacInteractiveCodeSnippet.tsx
+++ b/src/app/components/content/IsaacInteractiveCodeSnippet.tsx
@@ -6,6 +6,7 @@ import {logAction, selectors, useAppDispatch, useAppSelector} from "../../state"
 import IsaacCodeSnippet from "./IsaacCodeSnippet";
 import {Alert, Button} from "reactstrap";
 import {Loading} from "../handlers/IsaacSpinner";
+import {Link} from "react-router-dom";
 
 interface IsaacInteractiveCodeProps {doc: InteractiveCodeSnippetDTO}
 
@@ -112,7 +113,7 @@ export const IsaacInteractiveCodeSnippet = ({doc}: IsaacInteractiveCodeProps) =>
     return iframeState === "timeout"
         ? <>
             <IsaacCodeSnippet doc={doc} />
-            <Alert color={"warning"}>Sorry! The {SITE_TITLE_SHORT} code editor doesn't seem to be working at the moment. Please <Button color={"link"}>report this to us</Button> and try again later.</Alert>
+            <Alert color={"warning"}>Sorry! The {SITE_TITLE_SHORT} code editor doesn't seem to be working at the moment. Please <Button tag={Link} to={"/contact?subject=Code%20editor%20issue"} color={"link"}>report this to us</Button> and try again later.</Alert>
         </>
         : <>
             {iframeState !== "initialised" && <Loading className={"my-4"}/>}

--- a/src/app/components/content/IsaacInteractiveCodeSnippet.tsx
+++ b/src/app/components/content/IsaacInteractiveCodeSnippet.tsx
@@ -1,8 +1,11 @@
 import React, {useEffect, useRef, useState} from "react";
 import {InteractiveCodeSnippetDTO} from "../../../IsaacApiTypes";
-import {CODE_EDITOR_BASE_URL, useIFrameMessages} from "../../services";
+import {CODE_EDITOR_BASE_URL, SITE_TITLE_SHORT, useIFrameMessages} from "../../services";
 import {v4 as uuid_v4} from "uuid";
 import {logAction, selectors, useAppDispatch, useAppSelector} from "../../state";
+import IsaacCodeSnippet from "./IsaacCodeSnippet";
+import {Alert, Button} from "reactstrap";
+import {Loading} from "../handlers/IsaacSpinner";
 
 interface IsaacInteractiveCodeProps {doc: InteractiveCodeSnippetDTO}
 
@@ -11,10 +14,10 @@ export const IsaacInteractiveCodeSnippet = ({doc}: IsaacInteractiveCodeProps) =>
     const iframeRef = useRef<HTMLIFrameElement>(null);
     const uid = useRef((doc?.id || "") + uuid_v4().slice(0, 8));
     const {receivedData, sendMessage} = useIFrameMessages(uid.current, iframeRef);
-    const [loaded, setLoaded] = useState<boolean>(false);
+    const [iframeState, setIframeState] = useState<"loading" | "loaded" | "initialised" | "timeout">("loading");
+    const [initDelay, setInitDelay] = useState<number>(50);
 
     function sendQuestion() {
-        setLoaded(true);
         sendMessage({
             type: "initialise",
             code: doc.code,
@@ -25,13 +28,33 @@ export const IsaacInteractiveCodeSnippet = ({doc}: IsaacInteractiveCodeProps) =>
         });
     }
 
+    useEffect(() => {
+        if (iframeState !== "loaded") return;
+        // If the iframe has not confirmed initialisation after ~5-7 seconds, give up and display the code in a normal code block
+        if (initDelay > 5000) {
+            setIframeState("timeout");
+            console.error("Loading code editor iframe failed... displaying code in a normal code block instead");
+            return;
+        }
+        const timeout = setTimeout(() => {
+            sendQuestion();
+            setInitDelay(d => d * 2);
+        }, initDelay);
+        return () => clearTimeout(timeout);
+    }, [iframeState, initDelay]);
+
     const segueEnvironment = useAppSelector(selectors.segue.environmentOrUnknown);
     const [iFrameHeight, setIFrameHeight] = useState(100);
 
     useEffect(() => {
-        if (!loaded || undefined === receivedData) return;
+        if (!iframeState || undefined === receivedData) return;
 
         switch (receivedData.type) {
+            case "confirmInitialised":
+                // This is the first message sent by the iframe, and is used to confirm that the iframe had received
+                // the initialisation message
+                setIframeState("initialised");
+                break;
             case "log":
             case "checkerFail":
             case "setupFail":
@@ -86,13 +109,22 @@ export const IsaacInteractiveCodeSnippet = ({doc}: IsaacInteractiveCodeProps) =>
         }
     }, [receivedData, segueEnvironment]);
 
-    return <iframe title={"Code Sandbox"} src={CODE_EDITOR_BASE_URL + "/#" + uid.current} ref={iframeRef} onLoad={sendQuestion} className={"isaac-code-iframe w-100 mb-1"} style={
-        {
-            resize: "none",
-            height: iFrameHeight,
-            border: "none",
-            overflow: "hidden",
-            backgroundColor: "transparent"
-        }
-    } scrolling="no" allowTransparency={true} frameBorder={0} allow={"clipboard-read; clipboard-write"}/>;
+    return iframeState === "timeout"
+        ? <>
+            <IsaacCodeSnippet doc={doc} />
+            <Alert color={"warning"}>Sorry! The {SITE_TITLE_SHORT} code editor doesn't seem to be working at the moment. Please <Button color={"link"}>report this to us</Button> and try again later.</Alert>
+        </>
+        : <>
+            {iframeState !== "initialised" && <Loading className={"my-4"}/>}
+            <iframe title={"Code Sandbox"} src={CODE_EDITOR_BASE_URL + "/#" + uid.current} ref={iframeRef} onLoad={() => setIframeState("loaded")} className={"isaac-code-iframe w-100 mb-1"} style={
+                {
+                    resize: "none",
+                    height: iFrameHeight,
+                    border: "none",
+                    overflow: "hidden",
+                    backgroundColor: "transparent",
+                    display: iframeState !== "initialised" ? "none" : "block",
+                }
+            } scrolling="no" allowTransparency={true} frameBorder={0} allow={"clipboard-read; clipboard-write"}/>
+        </>;
 }

--- a/src/app/components/handlers/IsaacSpinner.tsx
+++ b/src/app/components/handlers/IsaacSpinner.tsx
@@ -21,7 +21,8 @@ export const IsaacSpinner = ({size = "md", className, color = "primary", inline 
         : <div role="status" className="pb-1">{contents}</div>;
 };
 
-export const Loading = ({noText}: {noText?: boolean}) => <div className="w-100 text-center pb-2">
-    {!noText && <h2 aria-hidden="true" className="pt-5">Loading...</h2>}
-    <IsaacSpinner />
-</div>;
+export const Loading = ({noText, className}: {noText?: boolean; className?: string}) =>
+    <div className={classNames(className, "w-100 text-center pb-2")}>
+        {!noText && <h2 aria-hidden="true" className="pt-5">Loading...</h2>}
+        <IsaacSpinner />
+    </div>;

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -75,7 +75,7 @@ export const SOCIAL_LINKS = siteSpecific(
 );
 
 // Change to "http://localhost:3000" if you want to run a local version of the code editor
-export const CODE_EDITOR_BASE_URL = "https://editor.isaaccode.org";
+export const CODE_EDITOR_BASE_URL = "http://localhost:3000";//"https://editor.isaaccode.org";
 
 export const API_REQUEST_FAILURE_MESSAGE = `There may be an error connecting to the ${siteSpecific("Isaac", "Ada")} platform.`;
 export const QUESTION_ATTEMPT_THROTTLED_MESSAGE = "You have made too many attempts at this question. Please try again later!";

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -75,7 +75,7 @@ export const SOCIAL_LINKS = siteSpecific(
 );
 
 // Change to "http://localhost:3000" if you want to run a local version of the code editor
-export const CODE_EDITOR_BASE_URL = "http://localhost:3000";//"https://editor.isaaccode.org";
+export const CODE_EDITOR_BASE_URL = "https://editor.isaaccode.org";
 
 export const API_REQUEST_FAILURE_MESSAGE = `There may be an error connecting to the ${siteSpecific("Isaac", "Ada")} platform.`;
 export const QUESTION_ATTEMPT_THROTTLED_MESSAGE = "You have made too many attempts at this question. Please try again later!";

--- a/src/scss/cs/typography.scss
+++ b/src/scss/cs/typography.scss
@@ -90,7 +90,7 @@ strong, b {
 i, em {
   @extend .font-style-italic;
 }
-p, small {
+p, small, .alert {
   @extend .font-weight-regular;
   .btn-link {
     font-size: unset;


### PR DESCRIPTION
Send multiple initialisation messages until we get a confirmation from the editor frame.

Timeout after a few seconds and show a standard code snippet instead - much better than a broken editor iframe.